### PR TITLE
only publish to NPM when a new release is created

### DIFF
--- a/.github/workflows/publishNPM.yml
+++ b/.github/workflows/publishNPM.yml
@@ -1,6 +1,9 @@
 name: Publish
 
-on: release
+on:
+  release:
+    types:
+      - created
 
 jobs:
   build:

--- a/.github/workflows/publishNPM.yml
+++ b/.github/workflows/publishNPM.yml
@@ -1,9 +1,6 @@
 name: Publish
 
-on:
-  push:
-    branches:
-      - master
+on: release
 
 jobs:
   build:


### PR DESCRIPTION
pushing every time a new commit is made to master requires version bumps even for the smallest things or the CI fails